### PR TITLE
    allow custom error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# IDE directory
+/.idea
+/.vscode
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/auth.go
+++ b/auth.go
@@ -6,33 +6,33 @@ import (
 
 //NewUnauthorizedError return an UnauthorizedError that has error message msg and child error err.
 func NewUnauthorizedError(msg string, err error) *UnauthorizedError {
-	fne := newFnerror(msg, err, http.StatusUnauthorized, StatusUnauthorized)
+	fne := NewFnerror(msg, err, http.StatusUnauthorized, StatusUnauthorized)
 	return &UnauthorizedError{fne}
 }
 
 //NewWrongCredentialError return a WrongCredentialError that has error message msg and child error err.
 func NewWrongCredentialError(msg string, err error) *WrongCredentialError {
-	fne := newFnerror(msg, err, http.StatusUnauthorized, StatusWrongCredential)
+	fne := NewFnerror(msg, err, http.StatusUnauthorized, StatusWrongCredential)
 	return &WrongCredentialError{fne}
 }
 
 //NewForbiddenError return a ForbiddenError that has error message msg and child error err
 func NewForbiddenError(msg string, err error) *ForbiddenError {
-	fne := newFnerror(msg, err, http.StatusForbidden, StatusForbidden)
+	fne := NewFnerror(msg, err, http.StatusForbidden, StatusForbidden)
 	return &ForbiddenError{fne}
 }
 
 //UnauthorizedError indicates that the user has not been yet authenticated.
 type UnauthorizedError struct {
-	*finerror
+	*FinnoError
 }
 
 //WrongCredentialError indicates that the credentials (Ex. username or password) provided by the user is not correct.
 type WrongCredentialError struct {
-	*finerror
+	*FinnoError
 }
 
 //ForbiddenError indicates that the user has no permission to perform the specific action.
 type ForbiddenError struct {
-	*finerror
+	*FinnoError
 }

--- a/error.go
+++ b/error.go
@@ -5,8 +5,9 @@ import (
 	"runtime"
 )
 
-func newFnerror(msg string, err error, httpCode, errCode int) *finerror {
-	return &finerror{
+func NewFnerror(msg string, err error, httpCode int, errCode string) *FinnoError {
+
+	return &FinnoError{
 		msg:      msg,
 		err:      err,
 		frame:    getFrame(),
@@ -15,15 +16,15 @@ func newFnerror(msg string, err error, httpCode, errCode int) *finerror {
 	}
 }
 
-type finerror struct {
+type FinnoError struct {
 	msg      string
 	err      error
 	frame    runtime.Frame
-	errCode  int
+	errCode  string
 	httpCode int
 }
 
-func (e *finerror) Error() string {
+func (e *FinnoError) Error() string {
 	if e.msg == "" {
 		return http.StatusText(e.GetHTTPCode())
 	}
@@ -31,20 +32,20 @@ func (e *finerror) Error() string {
 }
 
 //GetCode return the application error code.
-func (e *finerror) GetCode() int {
+func (e *FinnoError) GetCode() string {
 	return e.errCode
 }
 
 //GetHTTPCode return http response status code which related to the error.
-func (e *finerror) GetHTTPCode() int {
+func (e *FinnoError) GetHTTPCode() int {
 	return e.httpCode
 }
 
-func (e *finerror) GetTrace() string {
+func (e *FinnoError) GetTrace() string {
 	return getTrace(e.Error(), e.frame)
 }
 
 //Unwrap return the child error of the error, mostly used for extracting errors chain.
-func (e *finerror) Unwrap() error {
+func (e *FinnoError) Unwrap() error {
 	return e.err
 }

--- a/error.go
+++ b/error.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 )
 
+//NewFnerror return a custom FinnoError error which implement fnerror.Apperror
 func NewFnerror(msg string, err error, httpCode int, errCode string) *FinnoError {
 
 	return &FinnoError{

--- a/fnerror.go
+++ b/fnerror.go
@@ -1,89 +1,89 @@
 package fnerror
 
 import (
-	"fmt"
-	"runtime"
+    "fmt"
+    "runtime"
 )
 
 //Apperror interface which is used as a standard error across entire application.
 type Apperror interface {
-	Error() string
-	//GetCode return the application error code.
-	GetCode() int
-	//GetHTTPCode return http response status code which related to the error.
-	GetHTTPCode() int
-	//GetTrace return
-	GetTrace() string
-	//Unwrap return the child error of the error, mostly used for extracting errors chain.
-	Unwrap() error
+    Error() string
+    //GetCode return the application error code.
+    GetCode() string
+    //GetHTTPCode return http response status code which related to the error.
+    GetHTTPCode() int
+    //GetTrace return
+    GetTrace() string
+    //Unwrap return the child error of the error, mostly used for extracting errors chain.
+    Unwrap() error
 }
 
 //Client Error Code
 const (
-	StatusBadRequest = iota + 100
-	StatusNotFound
-	StatusMissingRequiredParameter
-	StatusValidation
-	StatusTimeout
-	StatusUnprocessableEntity
-	StatusTooManyRequests
-	StatusPayloadTooLarge
+    StatusBadRequest               = "FN100"
+    StatusNotFound                 = "FN101"
+    StatusMissingRequiredParameter = "FN102"
+    StatusValidation               = "FN103"
+    StatusTimeout                  = "FN104"
+    StatusUnprocessableEntity      = "FN105"
+    StatusTooManyRequests          = "FN106"
+    StatusPayloadTooLarge          = "FN107"
 )
 
 //Server Error Code
 const (
-	StatusServiceUnavailable = iota + 200
-	StatusUnexpected         = 999
+    StatusServiceUnavailable = "FN200"
+    StatusUnexpected         = "FN999"
 )
 
 //Authorization Error Code
 const (
-	StatusUnauthorized = iota + 300
-	StatusWrongCredential
-	StatusForbidden
+    StatusUnauthorized    = "FN300"
+    StatusWrongCredential = "FN301"
+    StatusForbidden       = "FN302"
 )
 
 func getFrame() runtime.Frame {
-	stackBuf := make([]uintptr, 50)
-	length := runtime.Callers(3, stackBuf[:])
-	stack := stackBuf[:length]
-	frames := runtime.CallersFrames(stack)
-	frame, _ := frames.Next()
-	return frame
+    stackBuf := make([]uintptr, 50)
+    length := runtime.Callers(3, stackBuf[:])
+    stack := stackBuf[:length]
+    frames := runtime.CallersFrames(stack)
+    frame, _ := frames.Next()
+    return frame
 }
 
 func getTrace(msg string, frame runtime.Frame) string {
-	trace := fmt.Sprintf(
-		"Message: \"%s\"\nFrom: %s()\n --- at %s:%d",
-		msg, frame.Function, frame.File, frame.Line)
-	return trace
+    trace := fmt.Sprintf(
+        "Message: \"%s\"\nFrom: %s()\n --- at %s:%d",
+        msg, frame.Function, frame.File, frame.Line)
+    return trace
 }
 
 //GetChainTrace Get Errors trace
 func GetChainTrace(e Apperror) string {
-	chainTrace := ""
-	cause := ""
-	trace := e.GetTrace()
-	err := e.Unwrap()
-	for {
-		if err == nil {
-			break
-		}
-		apperr, ok := err.(Apperror)
-		if ok {
-			trace += "\n" + apperr.GetTrace()
-		} else {
-			cause += err.Error()
-			break
-		}
-		err = apperr.Unwrap()
-	}
+    chainTrace := ""
+    cause := ""
+    trace := e.GetTrace()
+    err := e.Unwrap()
+    for {
+        if err == nil {
+            break
+        }
+        apperr, ok := err.(Apperror)
+        if ok {
+            trace += "\n" + apperr.GetTrace()
+        } else {
+            cause += err.Error()
+            break
+        }
+        err = apperr.Unwrap()
+    }
 
-	if cause == "" {
-		chainTrace = trace
-	} else {
-		cause = fmt.Sprintf("Original Error: \"%s\"", cause)
-		chainTrace = fmt.Sprintf("%s\n%s", trace, cause)
-	}
-	return chainTrace
+    if cause == "" {
+        chainTrace = trace
+    } else {
+        cause = fmt.Sprintf("Original Error: \"%s\"", cause)
+        chainTrace = fmt.Sprintf("%s\n%s", trace, cause)
+    }
+    return chainTrace
 }

--- a/server.go
+++ b/server.go
@@ -7,22 +7,22 @@ import (
 //NewUnexpectedError return a UnexpectedError that has error message msg and child error err.
 //Noted that msg should be empty string("") as it is not the best practice to expose the unhandled message to the caller.
 func NewUnexpectedError(msg string, err error) *UnexpectedError {
-	fne := newFnerror(msg, err, http.StatusInternalServerError, StatusUnexpected)
+	fne := NewFnerror(msg, err, http.StatusInternalServerError, StatusUnexpected)
 	return &UnexpectedError{fne}
 }
 
 //NewServiceUnavailableError return a ServiceUnavailableError that has error message msg and child error err.
 func NewServiceUnavailableError(msg string, err error) *ServiceUnavailableError {
-	fne := newFnerror(msg, err, http.StatusServiceUnavailable, StatusServiceUnavailable)
+	fne := NewFnerror(msg, err, http.StatusServiceUnavailable, StatusServiceUnavailable)
 	return &ServiceUnavailableError{fne}
 }
 
 //UnexpectedError is used when something is not expected or unhandled by the server.
 type UnexpectedError struct {
-	*finerror
+	*FinnoError
 }
 
 //ServiceUnavailableError indicates the the service is not ready to handle the request or it is down for maintenance or overloaded.
 type ServiceUnavailableError struct {
-	*finerror
+	*FinnoError
 }

--- a/user.go
+++ b/user.go
@@ -6,88 +6,88 @@ import (
 
 //NewNotFoundError return a NotFoundError that has error message msg and child error err.
 func NewNotFoundError(msg string, err error) *NotFoundError {
-	fne := newFnerror(msg, err, http.StatusNotFound, StatusNotFound)
+	fne := NewFnerror(msg, err, http.StatusNotFound, StatusNotFound)
 	return &NotFoundError{fne}
 }
 
 //NewPayloadTooLargeError return a PayloadTooLargeError that has error message msg and child error err.
 func NewPayloadTooLargeError(msg string, err error) *PayloadTooLargeError {
-	fne := newFnerror(msg, err, http.StatusRequestEntityTooLarge, StatusPayloadTooLarge)
+	fne := NewFnerror(msg, err, http.StatusRequestEntityTooLarge, StatusPayloadTooLarge)
 	return &PayloadTooLargeError{fne}
 }
 
 //NewTimoutError return a TimeoutError that has error message msg and child error err.
 func NewTimoutError(msg string, err error) *TimeoutError {
-	fne := newFnerror(msg, err, http.StatusRequestTimeout, StatusTimeout)
+	fne := NewFnerror(msg, err, http.StatusRequestTimeout, StatusTimeout)
 	return &TimeoutError{fne}
 }
 
 //NewValidationError return a ValidationError that has error message msg and child error err.
 func NewValidationError(msg string, err error) *ValidationError {
-	fne := newFnerror(msg, err, http.StatusBadRequest, StatusValidation)
+	fne := NewFnerror(msg, err, http.StatusBadRequest, StatusValidation)
 	return &ValidationError{fne}
 }
 
 //NewMissingRequiredParamsError return a MissingRequiredParamsError that has error message msg and child error err.
 func NewMissingRequiredParamsError(msg string, err error) *MissingRequiredParamsError {
-	fne := newFnerror(msg, err, http.StatusBadRequest, StatusMissingRequiredParameter)
+	fne := NewFnerror(msg, err, http.StatusBadRequest, StatusMissingRequiredParameter)
 	return &MissingRequiredParamsError{fne}
 }
 
 //NewUnprocessableEntityError return an UnprocessableEntityError that has error message msg and child error err.
 func NewUnprocessableEntityError(msg string, err error) *UnprocessableEntityError {
-	fne := newFnerror(msg, err, http.StatusUnprocessableEntity, StatusUnprocessableEntity)
+	fne := NewFnerror(msg, err, http.StatusUnprocessableEntity, StatusUnprocessableEntity)
 	return &UnprocessableEntityError{fne}
 }
 
 //NewTooManyRequestError return a TooManyRequestError that has error message msg and child error err.
 func NewTooManyRequestError(msg string, err error) *TooManyRequestError {
-	fne := newFnerror(msg, err, http.StatusTooManyRequests, StatusTooManyRequests)
+	fne := NewFnerror(msg, err, http.StatusTooManyRequests, StatusTooManyRequests)
 	return &TooManyRequestError{fne}
 }
 
 //NewBadRequestError return a BadRequestError that has error message msg and child error err.
 func NewBadRequestError(msg string, err error) *BadRequestError {
-	fne := newFnerror(msg, err, http.StatusBadRequest, StatusBadRequest)
+	fne := NewFnerror(msg, err, http.StatusBadRequest, StatusBadRequest)
 	return &BadRequestError{fne}
 }
 
 //NotFoundError indicates that the requested resource could not be found. | http: 404
 type NotFoundError struct {
-	*finerror
+	*FinnoError
 }
 
 //PayloadTooLargeError indicates that the payload's size exceed the limit of the server. | http: 413
 type PayloadTooLargeError struct {
-	*finerror
+	*FinnoError
 }
 
 //TimeoutError indicates that the process did not receive a response in time.
 type TimeoutError struct {
-	*finerror
+	*FinnoError
 }
 
 //ValidationError indicates that the request could not be understood by the server due to malformed syntax.
 type ValidationError struct {
-	*finerror
+	*FinnoError
 }
 
 //MissingRequiredParamsError is used when the request doesn't provide sufficient parameters to the server.
 type MissingRequiredParamsError struct {
-	*finerror
+	*FinnoError
 }
 
 //UnprocessableEntityError indicates that the request could be understood by the server(syntactically correct), but somehow could not be able to proccess the request.
 type UnprocessableEntityError struct {
-	*finerror
+	*FinnoError
 }
 
 //TooManyRequestError indicates that the user has sent too many request in a given amount of time
 type TooManyRequestError struct {
-	*finerror
+	*FinnoError
 }
 
 //BadRequestError indicates that the server cannot or will not process the request due to something that is perceived
 type BadRequestError struct {
-	*finerror
+	*FinnoError
 }


### PR DESCRIPTION
### Description
เนื่องจากว่าbuilt-in errorsที่go-fnerrorมีให้ตอนนี้นั้นมีอยู่จำกัดและไม่สามารถcustomizeได้ ในPRเลยจะเปิดให้สามารถสร้างerrorเองได้โดยสามารถcreate `FinnoError` ซึ่ง implement `Apperror` ผ่านfunction
 **`NewFnerror(msg string, err error, httpCode int, errCode string)`**

### Break Change (สำหรับversion 0.2.0 ลงไป)
ในPRนี้จะทำการเปลี่ยนMethod Signature ของ method `GetCode()` ใน interface Apperror  จาก 
**`GetCode() int`** ไปเป็น **`GetCode() string`**  และเปลี่ยนerror constants ทั้งหมดจากintให้เป็นstring เพื่อให้สามารถcustomize error codeได้หลากหลายขึ้น
### Example

```
import (
	fne "github.com/finnomena/go-fnerror"
	"net/http"
)
type BefundUnexpectedError struct {
	*fne.FinnoError
}

func NewBefundUnexpectedError(msg string, err error) *BefundUnexpectedError {
	finnoError := fne.NewFnerror(msg, err, http.StatusInternalServerError, StatusBefundUnexpected)
	return &BefundUnexpectedError{FinnoError: finnoError}
}
```




